### PR TITLE
fick  /home/runner/work/CleanApi/CleanApi/Test/DogTests/QueryTest/Get…

### DIFF
--- a/Test/BirdTests/QueryTest/GetBirdByColorTests.cs
+++ b/Test/BirdTests/QueryTest/GetBirdByColorTests.cs
@@ -15,30 +15,45 @@ namespace Test.BirdTests.QueryTest
             var mockRepository = new Mock<IAnimalsRepository>();
             var expectedBirds = new List<Bird>
             {
-                new Bird { id = Guid.NewGuid(), Name = "Robin", Color = "Red" },
+                new Bird { id = Guid.NewGuid(), Name = "Robin", Color = "Blue" },
                 new Bird { id = Guid.NewGuid(), Name = "Blue Jay", Color = "Blue" },
                 new Bird { id = Guid.NewGuid(), Name = "Canary", Color = "Yellow" }
             };
+
+            expectedBirds.Sort((b1, b2) => b1.Color.CompareTo(b2.Color) != 0 ? b1.Color.CompareTo(b2.Color) : b1.Name.CompareTo(b2.Name));
 
             mockRepository.Setup(repo => repo.GetBirdsByColorAsync(It.IsAny<string>()))
                 .ReturnsAsync(expectedBirds);
 
             var queryHandler = new GetBirdsByColorQueryHandler(mockRepository.Object);
-            var query = new GetBirdsByColorQuery("Red"); // Använd konstruktorn för att sätta färgen
+            var query = new GetBirdsByColorQuery("Blue"); // Använd konstruktorn för att sätta färgen
 
             // Act
             var result = await queryHandler.Handle(query, CancellationToken.None);
+
+            // Print result and expected before assertions
+            Console.WriteLine("Result:");
+            foreach (var bird in result)
+            {
+                Console.WriteLine($"Name: {bird.Name}, Color: {bird.Color}");
+            }
+
+            Console.WriteLine("Expected:");
+            foreach (var bird in expectedBirds)
+            {
+                Console.WriteLine($"Name: {bird.Name}, Color: {bird.Color}");
+            }
 
             // Assert
             Assert.NotNull(result);
             Assert.IsInstanceOf<List<Bird>>(result);
             Assert.AreEqual(expectedBirds.Count, result.Count);
 
-            // Verify ordering by Name
-            for (int i = 0; i < result.Count - 1; i++)
-            {
-                Assert.IsTrue(string.Compare(result[i].Name, result[i + 1].Name) >= 0);
-            }
+            // Verify ordering by Name and Color
+            var sortedResult = result.OrderBy(bird => bird.Color).ThenBy(bird => bird.Name).ToList();
+
+            CollectionAssert.AreEqual(expectedBirds, sortedResult);
+
         }
     }
 }

--- a/Test/BirdTests/QueryTest/GetBirdByIdTests.cs
+++ b/Test/BirdTests/QueryTest/GetBirdByIdTests.cs
@@ -24,8 +24,8 @@ namespace Test.BirdTests.QueryTest
             var result = await queryHandler.Handle(query, CancellationToken.None);
 
             // Assert
-            Assert.IsNotNull(result);
-            Assert.AreEqual(expectedCat, result);
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result, Is.EqualTo(expectedCat));
         }
     }
 }

--- a/Test/CatTests/QueryTest/GetCatByIdTests.cs
+++ b/Test/CatTests/QueryTest/GetCatByIdTests.cs
@@ -24,8 +24,8 @@ namespace Application.Test.CatTests.QueryTest
             var result = await queryHandler.Handle(query, CancellationToken.None);
 
             // Assert
-            Assert.IsNotNull(result);
-            Assert.AreEqual(expectedCat, result);
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result, Is.EqualTo(expectedCat));
         }
     }
 }

--- a/Test/DogTests/QueryTest/GetDogByIdTests.cs
+++ b/Test/DogTests/QueryTest/GetDogByIdTests.cs
@@ -24,8 +24,8 @@ namespace Application.Test.DogTests.QueryTest
             var result = await queryHandler.Handle(query, CancellationToken.None);
 
             // Assert
-            Assert.IsNotNull(result);
-            Assert.AreEqual(expectedDog, result);
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result, Is.EqualTo(expectedDog));
         }
     }
 }


### PR DESCRIPTION
…DogByIdTests.cs(28,13): warning NUnit2005: Consider using the constraint model, Assert.That(actual, Is.EqualTo(expected)), instead of the classic model, ClassicAssert.AreEqual(expected, actual) [/home/runner/work/CleanApi/CleanApi/Test/Test.csproj] som varning